### PR TITLE
ThumbnailCtrl compatibility with Python 3.x

### DIFF
--- a/wx/lib/agw/thumbnailctrl.py
+++ b/wx/lib/agw/thumbnailctrl.py
@@ -1790,7 +1790,7 @@ class ScrolledThumbnail(wx.ScrolledWindow):
         :param `y`: the mouse `y` position.
         """
 
-        col = (x - self._tBorder)/(self._tWidth + self._tBorder)
+        col = (x - self._tBorder)//(self._tWidth + self._tBorder)
 
         if col >= self._cols:
             col = self._cols - 1
@@ -1942,7 +1942,7 @@ class ScrolledThumbnail(wx.ScrolledWindow):
             return
 
         # get row
-        row = self.GetSelection()/self._cols
+        row = self.GetSelection()//self._cols
         # calc position to scroll view
 
         paintRect = self.GetPaintRect()
@@ -2584,6 +2584,5 @@ class ScrolledThumbnail(wx.ScrolledWindow):
         self._checktext = True
 
         self.Refresh()
-
 
 


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

These changes should make ThumbnailCtrl work with Python 3.x. 

Fixes #1: ``wx/lib/agw/thumbnailctrl.py``

```python
1785 =    def GetItemIndex(self, x, y):
1793 -        col = (x - self._tBorder)/(self._tWidth + self._tBorder)
1793 +        col = (x - self._tBorder)//(self._tWidth + self._tBorder)

1938 =    def ScrollToSelected(self):
1945 -        row = self.GetSelection()/self._cols
1945 +        row = self.GetSelection()//self._cols
```

